### PR TITLE
Change Win32 ExitProcess to C func exit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -178,7 +178,7 @@ segment .data
 
 segment .text
 global main
-extern ExitProcess
+extern exit
 
 extern printf
 
@@ -190,8 +190,8 @@ main:
     lea     rcx, [msg]
     call    printf
 
-    xor     rax, rax
-    call    ExitProcess
+    xor     ecx, ecx
+    call    exit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You might be asking, "what on earth am I typing here?" at this point. We'll go


### PR DESCRIPTION
Calling C runtime function must also terminated by C runtime itself (exit). Calling printf and then call ExitProcess without CRT function leads to hang because that does not let the C runtime terminate as gracefully.

First argument also passed in `RCX`, `RAX` is used as return value. Did you mean `add rsp, 32; pop rbp; xor eax, eax; ret` ?